### PR TITLE
Embed add_field - defaults inline to False

### DIFF
--- a/src/components/Output.tsx
+++ b/src/components/Output.tsx
@@ -65,6 +65,7 @@ export default function Output({ embed }: { embed: Embed }) {
 					substeps.push(s`    name: ${field.name},`);
 					substeps.push(s`    value: ${field.value},`);
 					if (field.inline) substeps.push(`    inline: true`);
+					else 			  substeps.push(`    inline: false`);
 					substeps.push(`  },`);
 				}
 				substeps.push(`)`);
@@ -136,6 +137,7 @@ export default function Output({ embed }: { embed: Embed }) {
 				output += s`\nembed.add_field(name=${field.name},\n`;
 				output += s`                value=${field.value}`;
 				if (field.inline) output += `,\n                inline=True`;
+				else 			  output += `,\n                inline=False`;
 				output += ")";
 			}
 			output += "\n";

--- a/src/components/Output.tsx
+++ b/src/components/Output.tsx
@@ -65,7 +65,7 @@ export default function Output({ embed }: { embed: Embed }) {
 					substeps.push(s`    name: ${field.name},`);
 					substeps.push(s`    value: ${field.value},`);
 					if (field.inline) substeps.push(`    inline: true`);
-					else 			  substeps.push(`    inline: false`);
+					else substeps.push(`    inline: false`);
 					substeps.push(`  },`);
 				}
 				substeps.push(`)`);
@@ -137,7 +137,7 @@ export default function Output({ embed }: { embed: Embed }) {
 				output += s`\nembed.add_field(name=${field.name},\n`;
 				output += s`                value=${field.value}`;
 				if (field.inline) output += `,\n                inline=True`;
-				else 			  output += `,\n                inline=False`;
+				else output += `,\n                inline=False`;
 				output += ")";
 			}
 			output += "\n";


### PR DESCRIPTION
Hello, 

first of all I'd like to thank you for creating this webapp. I've been working on a discord bot for me and my friends and being able to preview the embeds has been so useful to me. 

While using the embed creator I've ran into a small inconvenience that gets more annoying the more you use the app. 

**discord.py**, I'm not sure if **discord.js** as well, defaults all added fields to `inline=True`. That means that there is no way of setting `inline=False` in your GUI. 

That's why I'd like to propose adding else to the condition that appends `inline` value in *src/components/Output.tsx* for both Python and Javascript implementations and default the field to `False`. 
```typescript
if (field.inline) output += `,\n                inline=True`;
else output += `,\n                inline=False`;
```
<sub>Please ignore that there are 2 commits, github was being a jerk with formating.</sub>